### PR TITLE
Ajax request fix

### DIFF
--- a/client/static/js/views/activate.js
+++ b/client/static/js/views/activate.js
@@ -15,7 +15,7 @@ PANDA.views.Activate = Backbone.View.extend({
         this.activation_key = activation_key;
 
         $.ajax({
-            url: '/check_activation_key/' + activation_key,
+            url: '/check_activation_key/' + activation_key + '/',
             dataType: 'json',
             type: 'GET',
             success: _.bind(function(data, status, xhr) {

--- a/client/static/js/views/reset_password.js
+++ b/client/static/js/views/reset_password.js
@@ -15,7 +15,7 @@ PANDA.views.ResetPassword = Backbone.View.extend({
         this.activation_key = activation_key;
 
         $.ajax({
-            url: '/check_activation_key/' + activation_key,
+            url: '/check_activation_key/' + activation_key + '/',
             dataType: 'json',
             type: 'GET',
             success: _.bind(function(data, status, xhr) {


### PR DESCRIPTION
There is an error when running under HTTPS with the activation key emails
This fix adds a trailing slash to the end of the activation urls.
